### PR TITLE
feat: add full size image fallback

### DIFF
--- a/fly-dynamic-image-resizer.php
+++ b/fly-dynamic-image-resizer.php
@@ -267,8 +267,19 @@ class Fly_Images {
 			}
 		}
 
-		// Something went wrong
-		return array();
+		// Something went wrong, try with full sized image
+    $img = wp_get_attachment_image_src( $attachment_id, 'full' );
+    if ( ! empty( $img ) ) {
+      return array(
+        'src' => $img[0],
+        'width' => $size[0],
+        'height' => $size[1],
+      );
+    }
+
+    // Totally wrong
+    return array();
+
 	}
 
 	/**


### PR DESCRIPTION
I've added a full image src fallback which might be useful when using fly-dynamic-image-resizer with `.svg` images.