### PR TITLE
permit image size height or width to be 0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ branches:
   only:
     - master
 
+services:
+  - mysql
+
 cache:
   directories:
     - vendor

--- a/inc/class-core.php
+++ b/inc/class-core.php
@@ -166,6 +166,8 @@ class Core {
 	/**
 	 * Add image sizes to be created on the fly.
 	 *
+	 * Either width or height can be zero (0), but not both.
+	 *
 	 * @param  string   $size_name
 	 * @param  integer  $width
 	 * @param  integer  $height
@@ -173,14 +175,26 @@ class Core {
 	 * @return boolean
 	 */
 	public function add_image_size( $size_name, $width = 0, $height = 0, $crop = false ) {
-		if ( empty( $size_name ) || ! $width || ! $height ) {
+		if ( empty( $size_name ) ) {
 			return false;
 		}
 
-		$this->_image_sizes[ $size_name ] = [
-			'size' => [ $width, $height ],
+		if ( ! $width && 0 !== $width ) {
+			return false;
+		}
+
+		if ( ! $height && 0 !== $height ) {
+			return false;
+		}
+
+		if ( 0 === $height && 0 === $width ) {
+			return false;
+		}
+
+		$this->_image_sizes [ $size_name ] = array(
+			'size' => array( $width, $height ),
 			'crop' => $crop,
-		];
+		);
 
 		return true;
 	}


### PR DESCRIPTION
WordPress permits passing 0 in for width or height to preserve
the aspect ratio of the newly resized image.

The logic present in the add_image_size function retuns false because
0 is a falsey value in PHP.

The change will still prevent image sizes from being registered where
both height and width are === 0.

## Checklist:
- [x] I've read the [Contributing page](https://github.com/junaidbhura/fly-dynamic-image-resizer/blob/master/CONTRIBUTING.md).
- [x] I've created an issue and referenced it here.
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.


ref issue #32 