### PR TITLE
Add filter to modify attachment path

### DIFF
--- a/inc/class-core.php
+++ b/inc/class-core.php
@@ -276,6 +276,7 @@ class Core {
 
 			// Get WP Image Editor Instance
 			$image_path   = get_attached_file( $attachment_id );
+			$image_path   = apply_filters( 'fly_attachment_path', $image_path, $attachment_id );
 			$image_editor = wp_get_image_editor( $image_path );
 			if ( ! is_wp_error( $image_editor ) ) {
 				// Create new image

--- a/inc/class-core.php
+++ b/inc/class-core.php
@@ -275,8 +275,13 @@ class Core {
 			$this->check_fly_dir();
 
 			// Get WP Image Editor Instance
-			$image_path   = get_attached_file( $attachment_id );
-			$image_path   = apply_filters( 'fly_attachment_path', $image_path, $attachment_id );
+			$image_path   = apply_filters(
+				'fly_attached_file',
+				get_attached_file( $attachment_id ), 
+				$attachment_id
+				$size,
+				$crop
+			);
 			$image_editor = wp_get_image_editor( $image_path );
 			if ( ! is_wp_error( $image_editor ) ) {
 				// Create new image


### PR DESCRIPTION
## Checklist:
- [x] I've read the [Contributing page](https://github.com/junaidbhura/fly-dynamic-image-resizer/blob/master/CONTRIBUTING.md).
- [x] I've created an issue and referenced it here.
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.

## Description
Add a filter that can be used to modify image path before fly image thumbnail is generated. For more info see this issue https://github.com/junaidbhura/fly-dynamic-image-resizer/issues/33

## How has this been tested?
I have tested that the filter works and you can use a plugin / theme to modify the image path

## Types of changes
New feature (non-breaking change which adds functionality)


