### PR TITLE
Fix file extension case

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,9 +47,14 @@ jobs:
         composer global require wp-coding-standards/wpcs
         $HOME/.composer/vendor/bin/phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
 
-    - name: Install WordPress test suite
+    - name: Wait for MySQL
       run: |
-        bash bin/install-wp-tests.sh wordpress_test root root mysql ${{ matrix.wordpress-version }}
+        while ! mysqladmin ping -h mysql -u root -p${MYSQL_ROOT_PASSWORD}; do
+          sleep 1
+        done
+
+    - name: Install WordPress test suite
+      run: bash bin/install-wp-tests.sh wordpress_test root root mysql ${{ matrix.wordpress-version }}
 
     - name: Coding standards
       run: $HOME/.composer/vendor/bin/phpcs phpcs.ruleset.xml

--- a/fly-dynamic-image-resizer.php
+++ b/fly-dynamic-image-resizer.php
@@ -2,9 +2,9 @@
 /*
 Plugin Name: Fly Dynamic Image Resizer
 Description: Dynamically create image sizes on the fly!
-Version: 2.0.6
+Version: 2.0.7
 Author: Junaid Bhura
-Author URI: https://junaidbhura.com
+Author URI: https://junaid.dev
 Text Domain: fly-images
 */
 

--- a/inc/class-core.php
+++ b/inc/class-core.php
@@ -371,7 +371,7 @@ class Core {
 	 */
 	public function get_fly_file_name( $file_name, $width, $height, $crop ) {
 		$file_name_only = pathinfo( $file_name, PATHINFO_FILENAME );
-		$file_extension = pathinfo( $file_name, PATHINFO_EXTENSION );
+		$file_extension = strtolower( pathinfo( $file_name, PATHINFO_EXTENSION ) );
 
 		$crop_extension = '';
 		if ( true === $crop ) {

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,9 @@
 Contributors: junaidbhura
 Tags: media library, images, resize, dynamic, on the fly
 Requires at least: 3.0
-Tested up to: 5.4
-Stable tag: 2.0.6
+Tested up to: 5.5
+Requires PHP: 5.6
+Stable tag: 2.0.7
 
 Dynamically create image sizes on the fly!
 
@@ -125,6 +126,9 @@ Create dynamic image sizes in your PHP code!
 2. Delete individual images' cached fly images
 
 == Changelog ==
+
+= 2.0.7 =
+* Fix file extensions in edge cases [#38](https://github.com/junaidbhura/fly-dynamic-image-resizer/issues/38)
 
 = 2.0.6 =
 * New filter to potentially modify image path to work better with optimization plugins [#33](https://github.com/junaidbhura/fly-dynamic-image-resizer/issues/33)

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -155,6 +155,7 @@ class JB_Test_Fly_Plugin extends WP_UnitTestCase {
 	 */
 	function test_file_name() {
 		$this->assertEquals( 'test-200x100.jpg', self::$_core->get_fly_file_name( 'test.jpg', 200, 100, false ) );
+		$this->assertEquals( 'test-200x100.jpg', self::$_core->get_fly_file_name( 'test.JPG', 200, 100, false ) );
 		$this->assertEquals( 'test-200x100-c.jpg', self::$_core->get_fly_file_name( 'test.jpg', 200, 100, true ) );
 		$this->assertEquals( 'test-200x100-c.jpg', self::$_core->get_fly_file_name( 'test.jpg', 200.333, 100.5, true ) );
 		$this->assertEquals( 'test-200x100-lt.jpg', self::$_core->get_fly_file_name( 'test.jpg', 200, 100, array( 'left', 'top' ) ) );


### PR DESCRIPTION
Fixes #38 

Make sure the file extension is always lowercase for fly images to match the file created by ` wp_get_image_editor`.