### PR TITLE
Crop by coordinates (enhancement)

### DIFF
--- a/inc/class-core.php
+++ b/inc/class-core.php
@@ -256,6 +256,14 @@ class Core {
 					return array();
 			}
 
+			$is_crop_by_coordinates = is_array( $crop ) && isset( $crop[0] ) && isset( $crop[1] ) && is_numeric( $crop[0] );
+
+			//If it is a string and into a number value, then parse it as an integer.
+			if( $is_crop_by_coordinates && ( is_string( $crop[0] ) || is_string( $crop[1] ) ) ) {
+				$crop[0] = intval( $crop[0] );
+				$crop[1] = intval( $crop[1] );
+			}
+
 			// Get file path
 			$fly_dir       = $this->get_fly_dir( $attachment_id );
 			$fly_file_path = $fly_dir . DIRECTORY_SEPARATOR . $this->get_fly_file_name( basename( $image['file'] ), $width, $height, $crop );
@@ -293,7 +301,6 @@ class Core {
 
 			$image_editor = wp_get_image_editor( $image_path );
 			if ( ! is_wp_error( $image_editor ) ) {
-				$is_crop_by_coordinates = is_array( $crop ) && is_numeric( $crop[0] );
 
 				// Create new image
 				if( $is_crop_by_coordinates ) {


### PR DESCRIPTION
## Checklist:
- [x] I've read the [Contributing page](https://github.com/junaidbhura/fly-dynamic-image-resizer/blob/master/CONTRIBUTING.md).
- [x] I've created an issue and referenced it here. https://github.com/junaidbhura/fly-dynamic-image-resizer/issues/48
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.

## Description
Added the ability to select the cropping area in percent or in pixels.

Added new argument types for the crop attribute:

`$position = array('right', 'bottom'); //Normal use`

`$position = array(100, 300, 960, 1280); // Coordinates are relative to the original size.`
($x, $y, $custom_crop_width, $custoim_crop_height) - $custom_crop_* is a value for custom selection of the cropped area relative to the original image size. If one value is filled in and the other value is left blank or 0 is specified, then the value will be replaced with the original image size.
It should be borne in mind that the size of the cropping area should not exceed the size of the picture, otherwise the picture will be smaller than expected, l.e. this statement must be true: $x + $custom_crop_width <= $original_width

`$position = array((float) 1, (float) 1); // Floating point numbers are calculated as percentages, relative to their original size.`
This example is equivalent to array('right', 'bottom')

`$position = array((float) 0.6, (float) 0.5, 960, 1280); //Cuts out an area of 960x1280 from the center with a slight shift to the right.`

`echo fly_get_attachment_image(get_post_thumbnail_id(), array(480, 640), $position); //The returned image size will be 480x640.`


## How has this been tested?
I did not understand testing through a special testing program, I just checked on my project that all the entered data with different pictures work correctly.

## Types of changes
New feature (non-breaking change which adds functionality)


