### PR TITLE
Fix I18N Issues

### DIFF
--- a/admin/options.php
+++ b/admin/options.php
@@ -1,24 +1,24 @@
 <?php $fly_images = JB\FlyImages\Core::get_instance(); ?>
 <div class="wrap">
 
-	<h2>Fly Images</h2>
+	<h2><?php esc_html_e( 'Fly Images', 'fly-dynamic-image-resizer' ); ?></h2>
 
 	<div class="card">
-		<h3><?php esc_html_e( 'Fly Images Directory', 'fly-images' ); ?></h3>
+		<h3><?php esc_html_e( 'Fly Images Directory', 'fly-dynamic-image-resizer' ); ?></h3>
 		<p><code><?php echo esc_html( $fly_images->get_fly_dir() ); ?></code></p>
 		<?php if ( $fly_images->fly_dir_writable() ) : ?>
-			<p style="color: #7AD03A;"><?php esc_html_e( 'Writeable!', 'fly-images' ); ?></p>
+			<p style="color: #7AD03A;"><?php esc_html_e( 'Writeable!', 'fly-dynamic-image-resizer' ); ?></p>
 		<?php else : ?>
-			<p style="color: #A00;"><?php esc_html_e( 'Not Writeable. Please make sure this folder exists and is writeable!', 'fly-images' ); ?></p>
+			<p style="color: #A00;"><?php esc_html_e( 'Not Writeable. Please make sure this folder exists and is writeable!', 'fly-dynamic-image-resizer' ); ?></p>
 		<?php endif; ?>
 	</div> <!-- .card -->
 
 	<div class="card">
-		<h3><?php esc_html_e( 'Delete Cached Images', 'fly-images' ); ?></h3>
-		<p><?php esc_html_e( 'Do you want to delete the cached images created on the fly for all images?', 'fly-images' ); ?></p>
+		<h3><?php esc_html_e( 'Delete Cached Images', 'fly-dynamic-image-resizer' ); ?></h3>
+		<p><?php esc_html_e( 'Do you want to delete the cached images created on the fly for all images?', 'fly-dynamic-image-resizer' ); ?></p>
 		<form method="post" action="">
 			<?php wp_nonce_field( 'delete_all_fly_images', 'fly_nonce' ); ?>
-			<p class="submit"><input class="button-primary" value="<?php esc_html_e( 'Delete All Cached Images', 'fly-images' ); ?>" type="submit"></p>
+			<p class="submit"><input class="button-primary" value="<?php esc_html_e( 'Delete All Cached Images', 'fly-dynamic-image-resizer' ); ?>" type="submit"></p>
 		</form>
 	</div> <!-- .card -->
 

--- a/fly-dynamic-image-resizer.php
+++ b/fly-dynamic-image-resizer.php
@@ -5,7 +5,7 @@ Description: Dynamically create image sizes on the fly!
 Version: 2.0.8
 Author: Junaid Bhura
 Author URI: https://junaid.dev
-Text Domain: fly-images
+Text Domain: fly-dynamic-image-resizer
 */
 
 namespace JB\FlyImages;

--- a/inc/class-core.php
+++ b/inc/class-core.php
@@ -78,8 +78,8 @@ class Core {
 	 */
 	public function admin_menu_item() {
 		add_management_page(
-			__( 'Fly Images', 'fly-images' ),
-			__( 'Fly Images', 'fly-images' ),
+			__( 'Fly Images', 'fly-dynamic-image-resizer' ),
+			__( 'Fly Images', 'fly-dynamic-image-resizer' ),
 			$this->_capability,
 			'fly-images',
 			array( $this, 'options_page' )
@@ -99,7 +99,7 @@ class Core {
 		}
 
 		$url                         = wp_nonce_url( admin_url( 'tools.php?page=fly-images&delete-fly-image&ids=' . $post->ID ), 'delete_fly_image', 'fly_nonce' );
-		$actions['fly-image-delete'] = '<a href="' . esc_url( $url ) . '" title="' . esc_attr( __( 'Delete all cached image sizes for this image', 'fly-images' ) ) . '">' . __( 'Delete Fly Images', 'fly-images' ) . '</a>';
+		$actions['fly-image-delete'] = '<a href="' . esc_url( $url ) . '" title="' . esc_attr( __( 'Delete all cached image sizes for this image', 'fly-dynamic-image-resizer' ) ) . '">' . __( 'Delete Fly Images', 'fly-dynamic-image-resizer' ) . '</a>';
 
 		return $actions;
 	}
@@ -152,7 +152,7 @@ class Core {
 		) {
 			// Delete all fly images.
 			$this->delete_all_fly_images();
-			echo '<div class="updated"><p>' . esc_html__( 'All cached images created on the fly have been deleted.', 'fly-images' ) . '</p></div>';
+			echo '<div class="updated"><p>' . esc_html__( 'All cached images created on the fly have been deleted.', 'fly-dynamic-image-resizer' ) . '</p></div>';
 		} elseif (
 			isset( $_GET['delete-fly-image'], $_GET['ids'], $_GET['fly_nonce'] ) // Input var okay.
 			&& wp_verify_nonce( sanitize_key( $_GET['fly_nonce'] ), 'delete_fly_image' ) // Input var okay.
@@ -163,7 +163,7 @@ class Core {
 				foreach ( $ids as $id ) {
 					$this->delete_attachment_fly_images( $id );
 				}
-				echo '<div class="updated"><p>' . esc_html__( 'Deleted all fly images for this image.', 'fly-images' ) . '</p></div>';
+				echo '<div class="updated"><p>' . esc_html__( 'Deleted all fly images for this image.', 'fly-dynamic-image-resizer' ) . '</p></div>';
 			}
 		}
 

--- a/inc/class-fly-cli.php
+++ b/inc/class-fly-cli.php
@@ -13,11 +13,11 @@ class Fly_CLI extends WP_CLI_Command {
 	 */
 	public function delete_all( $args, $args_assoc ) {
 		$fly_images = Core::get_instance();
-		WP_CLI::line( esc_html__( 'Deleting all fly images...', 'fly-images' ) );
+		WP_CLI::line( esc_html__( 'Deleting all fly images...', 'fly-dynamic-image-resizer' ) );
 		if ( $fly_images->delete_all_fly_images() ) {
-			WP_CLI::success( esc_html__( 'All fly images deleted.', 'fly-images' ) );
+			WP_CLI::success( esc_html__( 'All fly images deleted.', 'fly-dynamic-image-resizer' ) );
 		} else {
-			WP_CLI::error( esc_html__( 'There was a problem deleting the fly images.', 'fly-images' ) );
+			WP_CLI::error( esc_html__( 'There was a problem deleting the fly images.', 'fly-dynamic-image-resizer' ) );
 		}
 	}
 
@@ -30,16 +30,16 @@ class Fly_CLI extends WP_CLI_Command {
 	public function delete_ids( $args, $args_assoc ) {
 		$ids = array_map( 'trim', explode( ',', $args[0] ) );
 		if ( empty( $ids ) ) {
-			WP_CLI::error( esc_html__( 'Please enter valid IDs.', 'fly-images' ) );
+			WP_CLI::error( esc_html__( 'Please enter valid IDs.', 'fly-dynamic-image-resizer' ) );
 		}
 
 		$fly_images = Core::get_instance();
 		foreach ( $ids as $id ) {
-			WP_CLI::line( esc_html__( 'Deleting: ', 'fly-images' ) . $id );
+			WP_CLI::line( esc_html__( 'Deleting: ', 'fly-dynamic-image-resizer' ) . $id );
 			$fly_images->delete_attachment_fly_images( $id );
 		}
 
-		WP_CLI::success( esc_html__( 'The selected fly images have been deleted.', 'fly-images' ) );
+		WP_CLI::success( esc_html__( 'The selected fly images have been deleted.', 'fly-dynamic-image-resizer' ) );
 	}
 
 }


### PR DESCRIPTION
Your plugin slug is fly-dynamic-image-resizer, but your Text Domain is fly-images. Change your Text Domain so it is equal to your slug and modify the text domain in all your source files. This change is needed because your "Requires at least" is below 4.6. (see https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains)

I modified related codes about the text-domain issues.

"Requires at least" (3.0) is below 4.6 so a load_plugin_textdomain is needed. (see https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#loading-text-domain)